### PR TITLE
Dont fail when there are no pocs

### DIFF
--- a/cvejson.py
+++ b/cvejson.py
@@ -14,10 +14,12 @@ def scantree(p):
 
 
 def parse_cve_md(b):
+    pocs = []
     y = yaml.load(b.split('\n---')[0], Loader=yaml.Loader)
     cve_id = y["id"]
-    pocs = [x for x in y["pocs"]]
-    pocs.sort()
+    if "pocs" in y:
+        pocs = [x for x in y["pocs"]]
+        pocs.sort()
     return cve_id, pocs
 
 


### PR DESCRIPTION
When parsing a cve markdown that has no pocs, the script fails with error

```
Traceback (most recent call last):
  File "../cvejson/cvejson.py", line 50, in <module>
    main()
  File "../cvejson/cvejson.py", line 38, in main
    cve_id, pocs = parse_cve_md(file.read())
  File "../cvejson/cvejson.py", line 19, in parse_cve_md
    pocs = [x for x in y["pocs"]]
KeyError: 'pocs'
```

Not sure if this is the best way to achieve this, but seems to be working for me without side-effects.

This should also fix the github actions failing to build.
